### PR TITLE
flush cached datasource to persist participants

### DIFF
--- a/onyx-core/src/main/java/org/obiba/onyx/core/etl/participant/impl/AbstractCachedDatasourceProcessor.java
+++ b/onyx-core/src/main/java/org/obiba/onyx/core/etl/participant/impl/AbstractCachedDatasourceProcessor.java
@@ -20,12 +20,14 @@ import org.obiba.magma.support.VariableEntityBean;
 import org.obiba.magma.type.BinaryType;
 import org.obiba.onyx.core.data.DatasourceUtils;
 import org.obiba.onyx.core.domain.participant.Participant;
+import org.obiba.onyx.magma.EhCacheCachedDatasource;
 import org.obiba.onyx.magma.MagmaInstanceProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+
 
 /**
  * Base class more warming up {@link org.obiba.magma.support.CachedDatasource}.
@@ -99,6 +101,8 @@ public class AbstractCachedDatasourceProcessor {
       for(ValueTable table : datasource.getValueTables()) {
         if(isApplicable(datasource, table)) doCache((CachedValueTable) table, participants, evict);
       }
+
+      if(datasource instanceof EhCacheCachedDatasource) ((EhCacheCachedDatasource) datasource).flushCache();
     } catch(Exception e) {
       log.error("Unable to get tables of datasource: {}", datasource.getName(), e);
     }
@@ -143,5 +147,4 @@ public class AbstractCachedDatasourceProcessor {
       }
     }
   }
-
 }

--- a/onyx-core/src/main/java/org/obiba/onyx/core/etl/participant/impl/CachedDatasourceProcessor.java
+++ b/onyx-core/src/main/java/org/obiba/onyx/core/etl/participant/impl/CachedDatasourceProcessor.java
@@ -14,6 +14,7 @@ import org.obiba.onyx.core.domain.participant.Participant;
 import org.obiba.onyx.core.domain.statistics.AppointmentUpdateLog;
 import org.obiba.onyx.core.etl.participant.IInterviewPostProcessor;
 import org.obiba.onyx.core.etl.participant.IParticipantPostProcessor;
+import org.obiba.onyx.magma.EhCacheCachedDatasource;
 import org.obiba.onyx.magma.MagmaInstanceProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -104,6 +105,8 @@ public class CachedDatasourceProcessor extends AbstractCachedDatasourceProcessor
       for(ValueTable table : datasource.getValueTables()) {
         if(isApplicable(datasource, table)) doCache(context, (CachedValueTable) table, participants);
       }
+
+      if(datasource instanceof EhCacheCachedDatasource) ((EhCacheCachedDatasource) datasource).flushCache();
     } catch(Exception e) {
       String msg = "Unable to get tables of datasource: " + datasource.getName();
       log(context, AppointmentUpdateLog.Level.ERROR, e, msg);

--- a/onyx-core/src/main/java/org/obiba/onyx/magma/EhCacheCachedDatasource.java
+++ b/onyx-core/src/main/java/org/obiba/onyx/magma/EhCacheCachedDatasource.java
@@ -1,0 +1,26 @@
+package org.obiba.onyx.magma;
+
+import org.obiba.magma.Datasource;
+import org.obiba.magma.VariableEntity;
+import org.obiba.magma.support.CachedDatasource;
+import org.springframework.cache.ehcache.EhCacheCache;
+
+public class EhCacheCachedDatasource extends CachedDatasource {
+
+  net.sf.ehcache.Cache ehCache;
+
+  public EhCacheCachedDatasource(Datasource wrapped, EhCacheCache cache) {
+    super(wrapped, cache);
+    this.ehCache = (net.sf.ehcache.Cache)cache.getNativeCache();
+  }
+
+  public void flushCache() {
+    this.ehCache.flush();
+  }
+
+  @Override
+  public void evictValues(VariableEntity variableEntity) {
+    super.evictValues(variableEntity);
+    this.ehCache.flush();
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1050,7 +1050,7 @@
     <quartz-scheduler.version>2.2.1</quartz-scheduler.version>
     <poi.version>3.9</poi.version>
     <rhino-js.version>1.7.7</rhino-js.version>
-    <magma.version>1.12.1</magma.version>
+    <magma.version>1.12-SNAPSHOT</magma.version>
     <meparser.version>0.0.6</meparser.version>
     <mysql-connector-java.version>5.1.36</mysql-connector-java.version>
     <pmd.ruleset.dir>${basedir}</pmd.ruleset.dir>


### PR DESCRIPTION
force ehcache flush to prevent improper cache shutdown on some situations, e.g. forced kill or windows process kill.