### PR TITLE
ONYX-1741 - change audio/webm extension and update default dictionar…

### DIFF
--- a/onyx-modules/quartz/quartz-core/src/main/java/org/obiba/onyx/quartz/core/engine/questionnaire/bundle/SupportedMedia.java
+++ b/onyx-modules/quartz/quartz-core/src/main/java/org/obiba/onyx/quartz/core/engine/questionnaire/bundle/SupportedMedia.java
@@ -29,7 +29,7 @@ public enum SupportedMedia {
   AUDIO_OGG(AUDIO, "audio/ogg", "oga"), //
   AUDIO_MPEG(AUDIO, "audio/mpeg", "mp3"), //
   AUDIO_MP4(AUDIO, "audio/mp4", "m4a"), //
-  AUDIO_WEBM(AUDIO, "audio/webm, webm"),
+  AUDIO_WEBM(AUDIO, "audio/webm, weba"),
 
   VIDEO_WEBM(VIDEO, "video/webm", "webm"), //
   VIDEO_OGG(VIDEO, "video/ogg", "ogv"), //

--- a/onyx-modules/quartz/quartz-core/src/main/java/org/obiba/onyx/quartz/magma/QuestionnaireStageVariableSourceFactory.java
+++ b/onyx-modules/quartz/quartz-core/src/main/java/org/obiba/onyx/quartz/magma/QuestionnaireStageVariableSourceFactory.java
@@ -649,7 +649,7 @@ public class QuestionnaireStageVariableSourceFactory implements VariableValueSou
     }
 
     private void visitAudioOpenAnswer(OpenAnswerDefinitionAudio audio, Builder builder) {
-      builder.mimeType("audio/x-wav");
+      builder.mimeType("audio/webm");
     }
 
     private void visitSuggestedOpenAnswer(OpenAnswerDefinitionSuggestion suggestion, Builder builder) {


### PR DESCRIPTION
…y mimeType to audio/webm.

Tested importing interviews in an opal project where the mime type for audio recording was already set to audio/x-wav. The result is that the mime type dictionary property was overridden to the new value (audio/webm).