### PR TITLE
Improvement - replace DefaultExecutionContextSerializer by explicit J…

### DIFF
--- a/onyx-core/src/main/resources/META-INF/spring/onyx-core/batch.xml
+++ b/onyx-core/src/main/resources/META-INF/spring/onyx-core/batch.xml
@@ -7,7 +7,7 @@
 
   <import resource="classpath*:/META-INF/onyx-job.xml" />
 
-  <bean id="batchDefaultSerializer" class="org.springframework.batch.core.repository.dao.DefaultExecutionContextSerializer" />
+  <bean id="batchDefaultSerializer" class="org.springframework.batch.core.repository.dao.Jackson2ExecutionContextStringSerializer" />
 
   <!-- Spring batch database schema property -->
   <bean id="jobRepository" class="org.springframework.batch.core.repository.support.JobRepositoryFactoryBean">

--- a/pom.xml
+++ b/pom.xml
@@ -1079,8 +1079,8 @@
     <servlet-api.version>3.0.1</servlet-api.version>
     <shiro.version>1.2.4</shiro.version>
     <slf4j.version>1.7.12</slf4j.version>
-    <spring.version>4.2.1.RELEASE</spring.version>
-    <spring-batch.version>3.0.4.RELEASE</spring-batch.version>
+    <spring.version>4.2.7.RELEASE</spring.version>
+    <spring-batch.version>3.0.7.RELEASE</spring-batch.version>
     <wicket.version>1.4.21</wicket.version>
     <wicket-nanogong.version>1.0</wicket-nanogong.version>
     <xstream.version>1.4.8</xstream.version>


### PR DESCRIPTION
…ackson2ExecutionContextStringSerialization.

Spring Batch 3.07.RELEASE is the earliest version where `Jackson2ExecutionContextStringSerializer` is implemented.
According to https://jira.spring.io/browse/BATCH-2575, xstream (and jettison) might cause serialization errors. Considering that the default serializer used will be the jacksonXML based one in Spring Batch 4, I suggest switching to it ASAP.  